### PR TITLE
Next.js Font 시스템으로 다크모드 전환 최적화

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,7 +1,22 @@
 import type { Metadata } from 'next';
+import { Press_Start_2P, Space_Mono } from 'next/font/google';
 import { Toaster } from 'sonner';
 import { getTheme } from './actions/theme';
 import './globals.css';
+
+const pixelFont = Press_Start_2P({
+  weight: ['400'],
+  subsets: ['latin'],
+  display: 'block',
+  preload: true,
+});
+
+const monoFont = Space_Mono({
+  weight: ['400', '700'],
+  subsets: ['latin'],
+  display: 'block',
+  preload: true,
+});
 
 export const metadata: Metadata = {
   title: {
@@ -46,19 +61,10 @@ export default async function RootLayout({
 }>) {
   const theme = await getTheme();
   return (
-    <html lang="ko" className={theme}>
-      <head>
-        <link rel="preconnect" href="https://fonts.googleapis.com" />
-        <link
-          rel="preconnect"
-          href="https://fonts.gstatic.com"
-          crossOrigin="anonymous"
-        />
-        <link
-          href="https://fonts.googleapis.com/css2?family=Press+Start+2P&family=Space+Mono:wght@400;700&display=swap"
-          rel="stylesheet"
-        />
-      </head>
+    <html
+      lang="ko"
+      className={`${pixelFont.className} ${monoFont.className} ${theme}`}
+    >
       <body
         suppressHydrationWarning
         className="mx-auto max-w-screen-sm font-mono"


### PR DESCRIPTION
## 주요 변경 사항
- 이전 PR(#48)에서 구현한 직접 구글 폰트 임포트 방식을 Next.js Font 시스템으로 전환
- 테마 전환 시 레이아웃 시프트 없이 동작하면서도 Next.js의 폰트 최적화 기능 활용
## 기존 PR과의 차이점
- PR #48: 구글 폰트 직접 임포트 방식으로 레이아웃 시프트 해결
- 현재 PR: Next.js Font 시스템을 사용하면서도 동일한 UI 안정성 제공 + 추가 성능 최적화