### PR TITLE
refactor(UI): CSS 변수를 Tailwind 네이밍 시스템으로 전환

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,33 @@
 # 5urf Twitter
 
-사용자들이 생각과 순간을 공유할 수 있는 플랫폼입니다.
+사용자들이 생각과 순간을 공유할 수 있는 소셜 미디어 플랫폼입니다.
 
-## 기술 스택
-
-### 프론트엔드
-
-- Next.js 15
-- TypeScript
-- TailwindCSS
-
-### 백엔드
-
-- Next.js API Routes & Server Actions
-- Prisma
-- iron-session
-
-## 기능
+## 주요 기능
 
 - 사용자 인증 (회원가입, 로그인, 로그아웃)
 - 트윗 작성, 수정, 삭제
 - 트윗에 좋아요 및 댓글 기능
 - 사용자 프로필 보기 및 수정
-- 트윗 검색 기능
+- 트윗 및 사용자명 검색 기능
+- 다크모드 지원 (라이트/다크 테마 전환)
 
-## 구조
+## 기술 스택
+
+### 프론트엔드
+
+- **Next.js 15**
+- **TypeScript**
+- **TailwindCSS**
+
+### 백엔드
+
+- **Next.js API Routes & Server Actions**
+- **Prisma**
+- **iron-session**
+- **bcryptjs**
+- **Zod**
+
+## 프로젝트 구조
 
 ```
 app/

--- a/app/(auth)/create-account/page.tsx
+++ b/app/(auth)/create-account/page.tsx
@@ -1,4 +1,5 @@
 'use client';
+import AuthPageHeader from '@/components/auth/AuthPageHeader';
 import FormButton from '@/components/form/FormButton';
 import FormInput from '@/components/form/FormInput';
 import { ACCOUNT_VALIDATION } from '@/lib/constants';
@@ -19,12 +20,7 @@ export default function CreateAccountPage() {
   return (
     <main className="flex min-h-screen items-center justify-center px-4">
       <section className="retro-container w-full max-w-md">
-        <figure className="mb-8 flex flex-col items-center justify-center gap-2">
-          <FileText className="size-14 text-[var(--text-primary)] dark:text-[var(--accent-primary)]" />
-          <h2 className="text-xl text-[var(--text-primary)] dark:text-[var(--accent-primary)]">
-            Create Account
-          </h2>
-        </figure>
+        <AuthPageHeader icon={FileText} title="Create Account" />
         <form onSubmit={onSubmit} className="space-y-4">
           <FormInput
             icon="email"

--- a/app/(auth)/create-account/page.tsx
+++ b/app/(auth)/create-account/page.tsx
@@ -3,6 +3,7 @@ import FormButton from '@/components/form/FormButton';
 import FormInput from '@/components/form/FormInput';
 import { ACCOUNT_VALIDATION } from '@/lib/constants';
 import { FileText } from 'lucide-react';
+import Link from 'next/link';
 import { startTransition, useActionState } from 'react';
 import { createAccount } from './actions';
 
@@ -62,6 +63,12 @@ export default function CreateAccountPage() {
           />
           <FormButton text="계정 만들기" type="submit" />
         </form>
+        <Link
+          href="/log-in"
+          className="mt-4 flex justify-center text-sm text-[var(--accent-primary)] transition hover:text-[var(--accent-secondary)] hover:underline"
+        >
+          계정이 이미 있으신가요? 로그인
+        </Link>
       </section>
     </main>
   );

--- a/app/(auth)/create-account/page.tsx
+++ b/app/(auth)/create-account/page.tsx
@@ -61,7 +61,7 @@ export default function CreateAccountPage() {
         </form>
         <Link
           href="/log-in"
-          className="mt-4 flex justify-center text-sm text-[var(--accent-primary)] transition hover:text-[var(--accent-secondary)] hover:underline"
+          className="mt-4 flex justify-center text-sm text-brand-primary transition hover:text-brand-secondary hover:underline"
         >
           계정이 이미 있으신가요? 로그인
         </Link>

--- a/app/(auth)/log-in/page.tsx
+++ b/app/(auth)/log-in/page.tsx
@@ -43,7 +43,7 @@ export default function LoginPage() {
         </form>
         <Link
           href="/create-account"
-          className="retro-button mt-4 flex justify-center border-[var(--border-primary)] bg-[var(--bg-tertiary)] py-3 text-sm text-[var(--text-primary)] hover:bg-[var(--hover-light)]"
+          className="retro-button mt-4 flex justify-center border-outline-primary bg-surface-tertiary py-3 text-sm text-content-primary hover:bg-interaction-secondary"
         >
           회원가입
         </Link>

--- a/app/(auth)/log-in/page.tsx
+++ b/app/(auth)/log-in/page.tsx
@@ -1,4 +1,5 @@
 'use client';
+import AuthPageHeader from '@/components/auth/AuthPageHeader';
 import FormButton from '@/components/form/FormButton';
 import FormInput from '@/components/form/FormInput';
 import { ACCOUNT_VALIDATION } from '@/lib/constants';
@@ -19,12 +20,7 @@ export default function LoginPage() {
   return (
     <main className="flex min-h-screen items-center justify-center px-4">
       <section className="retro-container w-full max-w-md">
-        <figure className="mb-8 flex flex-col items-center justify-center gap-2">
-          <Terminal className="size-14 text-[var(--text-primary)] dark:text-[var(--accent-primary)]" />
-          <h2 className="text-xl text-[var(--text-primary)] dark:text-[var(--accent-primary)]">
-            Log In
-          </h2>
-        </figure>
+        <AuthPageHeader icon={Terminal} title="Log In" />
         <form onSubmit={onSubmit} className="space-y-4">
           <FormInput
             icon="email"

--- a/app/(tabs)/(home)/loading.tsx
+++ b/app/(tabs)/(home)/loading.tsx
@@ -6,7 +6,7 @@ export default function LoadingHome() {
     <main className="mx-auto max-w-lg px-4 pb-10 pt-10">
       <PageHeader title="HOME" />
       <div className="retro-container mb-6">
-        <div className="min-h-20 w-full border-2 border-[var(--border-primary)] bg-[var(--bg-tertiary)] p-3" />
+        <div className="min-h-20 w-full border-2 border-outline-primary bg-surface-tertiary p-3" />
         <div className="mt-3 flex justify-end">
           <Skeleton className="h-10 w-20" />
         </div>

--- a/app/(tabs)/tweets/[id]/loading.tsx
+++ b/app/(tabs)/tweets/[id]/loading.tsx
@@ -6,10 +6,10 @@ export default function LoadingTweetDetail() {
     <main className="mx-auto max-w-lg px-4 pb-20 pt-5">
       <BackButton />
       <div className="retro-container overflow-hidden p-0">
-        <div className="border-b-2 border-[var(--border-primary)] p-5">
+        <div className="border-b-2 border-outline-primary p-5">
           <Skeleton className="h-5 w-32" />
         </div>
-        <div className="border-b-2 border-[var(--border-primary)] p-5">
+        <div className="border-b-2 border-outline-primary p-5">
           <div className="space-y-2">
             <Skeleton className="h-4 w-full" />
             <Skeleton className="h-4 w-full" />
@@ -24,13 +24,10 @@ export default function LoadingTweetDetail() {
         </div>
       </div>
       <div className="mt-6">
-        <div className="mb-4 h-6 w-32 animate-pulse bg-[var(--border-secondary)]" />
+        <div className="mb-4 h-6 w-32 animate-pulse bg-outline-secondary" />
         <div className="retro-container overflow-hidden p-0">
           {[...Array(2)].map((_, index) => (
-            <div
-              key={index}
-              className="border-b-2 border-[var(--border-primary)] p-4"
-            >
+            <div key={index} className="border-b-2 border-outline-primary p-4">
               <Skeleton className="mb-2 h-5 w-24" />
               <div className="space-y-2">
                 <Skeleton className="h-4 w-full" />
@@ -41,7 +38,7 @@ export default function LoadingTweetDetail() {
           ))}
         </div>
         <div className="retro-container mt-4">
-          <div className="h-24 w-full border-2 border-[var(--border-primary)] bg-[var(--bg-tertiary)]" />
+          <div className="h-24 w-full border-2 border-outline-primary bg-surface-tertiary" />
           <div className="mt-3 flex justify-end">
             <Skeleton className="h-10 w-24" />
           </div>

--- a/app/(tabs)/tweets/[id]/page.tsx
+++ b/app/(tabs)/tweets/[id]/page.tsx
@@ -161,7 +161,7 @@ export default async function TweetDetailPage({
     <main className="mx-auto max-w-lg px-4 pb-20 pt-5">
       <BackButton fallbackPath="/" />
       <div className="retro-container overflow-hidden p-0">
-        <div className="border-b-2 border-[var(--border-primary)] p-5">
+        <div className="border-b-2 border-outline-primary p-5">
           <Link
             href={`/users/${encodeURIComponent(tweet.user.username)}`}
             className="username-link"
@@ -169,7 +169,7 @@ export default async function TweetDetailPage({
             {tweet.user.username}
           </Link>
         </div>
-        <div className="border-b-2 border-[var(--border-primary)] p-5">
+        <div className="border-b-2 border-outline-primary p-5">
           <p className="whitespace-pre-wrap text-lg">{tweet.tweet}</p>
           <div className="mt-4 text-xs text-gray-500">
             {formatToKorDate(tweet.created_at)}
@@ -190,8 +190,8 @@ export default async function TweetDetailPage({
                   href={`/tweets/${id}/edit`}
                   className={cn(
                     'retro-button px-4 py-2 text-sm font-medium',
-                    'border-[var(--accent-primary)] bg-[var(--accent-primary)]',
-                    'text-white hover:bg-[var(--accent-secondary)] dark:text-black'
+                    'border-brand-primary bg-brand-primary',
+                    'text-white hover:bg-brand-secondary dark:text-black'
                   )}
                 >
                   수정

--- a/app/(tabs)/users/[username]/edit/page.tsx
+++ b/app/(tabs)/users/[username]/edit/page.tsx
@@ -71,12 +71,7 @@ export default function ProfileEditPage({ params }: IProfileEditPageProps) {
       <BackButton
         fallbackPath={`/users/${encodeURIComponent(decodedUsername)}`}
       />
-      <h1
-        className={cn(
-          'mb-6 text-xl font-medium',
-          'text-[var(--text-primary)] dark:text-[var(--accent-primary)]'
-        )}
-      >
+      <h1 className={cn('mb-6 text-xl font-medium text-brand-primary')}>
         프로필 편집
       </h1>
       {optimisticProfile && (

--- a/app/(tabs)/users/[username]/page.tsx
+++ b/app/(tabs)/users/[username]/page.tsx
@@ -108,7 +108,7 @@ export default async function UserProfilePage({
       <PageHeader title="PROFILE" />
       <div className="retro-container mb-6 p-6">
         <div className="flex items-center justify-between">
-          <h1 className="text-xl font-medium text-[var(--accent-primary)]">
+          <h1 className="text-xl font-medium text-brand-primary">
             {user.username}
           </h1>
           {isOwner && (
@@ -116,9 +116,9 @@ export default async function UserProfilePage({
               href={`/users/${user.username}/edit`}
               className={cn(
                 'retro-button flex items-center gap-1 px-4 py-2 text-sm',
-                'border-[var(--accent-primary)] bg-[var(--accent-primary)]',
-                'text-[var(--button-text-on-accent)] transition-colors',
-                'hover:border-[var(--accent-secondary)] hover:bg-[var(--accent-secondary)]'
+                'border-brand-primary bg-brand-primary',
+                'text-special-button-on-accent transition-colors',
+                'hover:border-brand-secondary hover:bg-brand-secondary'
               )}
             >
               <Pencil className="mr-1 size-4" />
@@ -127,19 +127,12 @@ export default async function UserProfilePage({
           )}
         </div>
         {user.bio && <p className="mt-3 whitespace-pre-wrap">{user.bio}</p>}
-        <div className="mt-4 text-sm text-[var(--text-secondary)]">
+        <div className="mt-4 text-sm text-content-secondary">
           가입일: {formatToKorDateOnly(user.created_at)}
         </div>
       </div>
 
-      <h2
-        className={cn(
-          'mb-4 text-lg',
-          'text-[var(--text-primary)] dark:text-[var(--accent-primary)]'
-        )}
-      >
-        작성한 트윗
-      </h2>
+      <h2 className={cn('mb-4 text-lg text-brand-primary')}>작성한 트윗</h2>
       {tweets.length > 0 ? (
         <>
           <TweetList tweets={tweets} />

--- a/app/globals.css
+++ b/app/globals.css
@@ -4,31 +4,29 @@
 
 @layer base {
   :root {
-    --bg-primary: #f9fafb; /* bg-gray-50 */
-    --bg-secondary: #ffffff; /* bg-white */
-    --bg-tertiary: #f3f4f6; /* bg-gray-100 */
+    --bg-primary: #f9fafb;
+    --bg-secondary: #ffffff;
+    --bg-tertiary: #f3f4f6;
 
-    --text-primary: #111827; /* text-gray-900 */
-    --text-secondary: #6b7280; /* text-gray-500 */
-    --text-tertiary: #9ca3af; /* text-gray-400 */
+    --text-primary: #111827;
+    --text-secondary: #6b7280;
+    --text-tertiary: #9ca3af;
 
-    --border-primary: #d1d5db; /* border-gray-300 */
-    --border-secondary: #e5e7eb; /* border-gray-200 */
+    --border-primary: #d1d5db;
+    --border-secondary: #e5e7eb;
 
-    --accent-primary: #3b82f6; /* text-blue-600 */
-    --accent-secondary: #2563eb; /* hover:bg-blue-700 */
-    --accent-light: #dbeafe; /* bg-blue-100 */
+    --accent-primary: #3b82f6;
+    --accent-secondary: #2563eb;
+    --accent-light: #dbeafe;
 
-    --error: #ef4444; /* text-red-500 */
-    --error-light: #fee2e2; /* bg-red-50 */
-    --success: #10b981; /* text-green-500 */
+    --error: #ef4444;
+    --error-light: #fee2e2;
+    --success: #10b981;
 
-    --hover-bg: #f3f4f6; /* hover:bg-gray-100 */
-    --hover-light: #f9fafb; /* hover:bg-gray-50 */
+    --hover-primary: #f3f4f6;
+    --hover-secondary: #f9fafb;
 
     --button-text-on-accent: #ffffff;
-
-    --shadow-retro: 0 4px 0 #d1d5db;
   }
 
   :root.dark {
@@ -51,12 +49,10 @@
     --error-light: #450a0a;
     --success: #86efac;
 
-    --hover-bg: #1f1f1f;
-    --hover-light: #171717;
+    --hover-primary: #1f1f1f;
+    --hover-secondary: #171717;
 
     --button-text-on-accent: #000000;
-
-    --shadow-retro: 0 0 10px rgba(134, 239, 172, 0.1);
   }
 
   body {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,7 +1,22 @@
 import type { Metadata } from 'next';
+import { Press_Start_2P, Space_Mono } from 'next/font/google';
 import { Toaster } from 'sonner';
 import { getTheme } from './actions/theme';
 import './globals.css';
+
+const pixelFont = Press_Start_2P({
+  weight: ['400'],
+  subsets: ['latin'],
+  display: 'block',
+  preload: true,
+});
+
+const monoFont = Space_Mono({
+  weight: ['400', '700'],
+  subsets: ['latin'],
+  display: 'block',
+  preload: true,
+});
 
 export const metadata: Metadata = {
   title: {
@@ -46,19 +61,10 @@ export default async function RootLayout({
 }>) {
   const theme = await getTheme();
   return (
-    <html lang="ko" className={theme}>
-      <head>
-        <link rel="preconnect" href="https://fonts.googleapis.com" />
-        <link
-          rel="preconnect"
-          href="https://fonts.gstatic.com"
-          crossOrigin="anonymous"
-        />
-        <link
-          href="https://fonts.googleapis.com/css2?family=Press+Start+2P&family=Space+Mono:wght@400;700&display=swap"
-          rel="stylesheet"
-        />
-      </head>
+    <html
+      lang="ko"
+      className={`${pixelFont.className} ${monoFont.className} ${theme}`}
+    >
       <body
         suppressHydrationWarning
         className="mx-auto max-w-screen-sm font-mono"

--- a/components/auth/AuthPageHeader.tsx
+++ b/components/auth/AuthPageHeader.tsx
@@ -19,10 +19,8 @@ export default function AuthPageHeader({
         className
       )}
     >
-      <Icon className="size-14 text-[var(--accent-primary)] dark:text-[var(--accent-primary)]" />
-      <h2 className="text-xl text-[var(--accent-primary)] dark:text-[var(--accent-primary)]">
-        {title}
-      </h2>
+      <Icon className="text-brand-primary size-14" />
+      <h2 className="text-brand-primary text-xl">{title}</h2>
     </figure>
   );
 }

--- a/components/auth/AuthPageHeader.tsx
+++ b/components/auth/AuthPageHeader.tsx
@@ -1,0 +1,28 @@
+import { cn } from '@/lib/utils';
+import { LucideIcon } from 'lucide-react';
+
+interface IAuthPageHeaderProps {
+  icon: LucideIcon;
+  title: string;
+  className?: string;
+}
+
+export default function AuthPageHeader({
+  icon: Icon,
+  title,
+  className,
+}: IAuthPageHeaderProps) {
+  return (
+    <figure
+      className={cn(
+        'mb-8 flex flex-col items-center justify-center gap-2',
+        className
+      )}
+    >
+      <Icon className="size-14 text-[var(--accent-primary)] dark:text-[var(--accent-primary)]" />
+      <h2 className="text-xl text-[var(--accent-primary)] dark:text-[var(--accent-primary)]">
+        {title}
+      </h2>
+    </figure>
+  );
+}

--- a/components/common/BackButton.tsx
+++ b/components/common/BackButton.tsx
@@ -34,7 +34,7 @@ export default function BackButton({
         onClick={handleClick}
         className={cn(
           'inline-flex items-center transition-colors',
-          'text-[var(--accent-primary)] hover:text-[var(--accent-secondary)]',
+          'text-brand-primary hover:text-brand-secondary',
           className
         )}
       >

--- a/components/common/LikeButton.tsx
+++ b/components/common/LikeButton.tsx
@@ -48,15 +48,15 @@ export default function LikeButton({
       disabled={isPending}
       className={cn(
         'retro-button flex items-center border-transparent bg-transparent px-2 py-1 transition-colors',
-        'text-[var(--text-secondary)]',
-        state.isLiked ? 'text-[var(--error)]' : 'hover:text-[var(--error)]',
+        'text-content-secondary',
+        state.isLiked ? 'text-status-error' : 'hover:text-status-error',
         isPending && 'cursor-not-allowed opacity-70'
       )}
     >
       <Heart
         className={cn(
           'size-5',
-          state.isLiked && 'fill-[var(--error)] text-[var(--error)]'
+          state.isLiked && 'fill-status-error text-statusfill-status-error'
         )}
       />
       <span className="ml-1">{state.likeCount}</span>

--- a/components/common/Pagination.tsx
+++ b/components/common/Pagination.tsx
@@ -45,7 +45,7 @@ export default function Pagination({
           'retro-button p-2 transition',
           isPrevDisabled
             ? 'cursor-not-allowed opacity-50'
-            : 'hover:bg-[var(--hover-light)] dark:hover:bg-[var(--hover-bg)]'
+            : 'hover:bg-interaction-primary'
         )}
         aria-disabled={isPrevDisabled}
         tabIndex={isPrevDisabled ? -1 : undefined}
@@ -53,7 +53,7 @@ export default function Pagination({
         <ChevronLeft className="size-5" />
       </Link>
 
-      <span className="retro-button bg-[var(--bg-secondary)] px-4 py-2 text-sm">
+      <span className="retro-button bg-surface-secondary px-4 py-2 text-sm">
         {currentPage} / {totalPages}
       </span>
 
@@ -65,7 +65,7 @@ export default function Pagination({
           'retro-button p-2 transition',
           isNextDisabled
             ? 'cursor-not-allowed opacity-50'
-            : 'hover:bg-[var(--hover-light)] dark:hover:bg-[var(--hover-bg)]'
+            : 'hover:bg-interaction-primary'
         )}
         aria-disabled={isNextDisabled}
         tabIndex={isNextDisabled ? -1 : undefined}

--- a/components/form/FormButton.tsx
+++ b/components/form/FormButton.tsx
@@ -25,9 +25,9 @@ export default function FormButton({
       disabled={disabled || pending}
       className={cn(
         'retro-button w-full py-3',
-        'border-[var(--accent-primary)] bg-[var(--accent-primary)]',
-        'text-[var(--button-text-on-accent)]',
-        'hover:border-[var(--accent-secondary)] hover:bg-[var(--accent-secondary)]',
+        'border-brand-primary bg-brand-primary',
+        'text-special-button-on-accent',
+        'hover:border-brand-secondary hover:bg-brand-secondary',
         'disabled:cursor-not-allowed disabled:opacity-70',
         className
       )}

--- a/components/form/FormInput.tsx
+++ b/components/form/FormInput.tsx
@@ -20,7 +20,7 @@ export default function FormInput({
   const hasError = errorMessages.length > 0;
 
   const renderIcon = () => {
-    const iconClass = 'size-5 text-[var(--accent-primary)]';
+    const iconClass = 'size-5 text-brand-primary';
     switch (icon) {
       case 'email':
         return <Mail className={iconClass} />;
@@ -42,9 +42,10 @@ export default function FormInput({
         <input
           className={cn(
             'retro-input w-full py-3 pl-12 pr-4',
-            'focus:border-[var(--accent-primary)] focus:outline-none focus:ring-0',
-            'transition placeholder:text-[var(--text-secondary)]',
-            hasError && 'border-[var(--error)] ring-1 ring-[var(--error)]',
+            'focus:border-brand-primary focus:outline-none focus:ring-0',
+            'placeholder:text-content-secondary transition',
+            hasError &&
+              'border-status-error ring-statuborder-status-error ring-1',
             className
           )}
           {...props}
@@ -53,7 +54,7 @@ export default function FormInput({
       {hasError && (
         <div className="px-1">
           {errorMessages.map((error, index) => (
-            <small key={index} className="block text-[var(--error)]">
+            <small key={index} className="text-status-error block">
               {error}
             </small>
           ))}

--- a/components/layout/EmptyState.tsx
+++ b/components/layout/EmptyState.tsx
@@ -15,11 +15,9 @@ export default function EmptyState({
 }: IEmptyStateProps) {
   return (
     <div className={cn('retro-container p-6 text-center', containerClassName)}>
-      <p className={cn('text-[var(--text-secondary)]', className)}>{title}</p>
+      <p className={cn('text-content-secondary', className)}>{title}</p>
       {description && (
-        <p className="mt-2 text-sm text-[var(--text-tertiary)]">
-          {description}
-        </p>
+        <p className="mt-2 text-sm text-content-secondary">{description}</p>
       )}
     </div>
   );

--- a/components/layout/PageHeader.tsx
+++ b/components/layout/PageHeader.tsx
@@ -8,10 +8,7 @@ interface IPageHeaderProps {
 export default function PageHeader({ title, className }: IPageHeaderProps) {
   return (
     <h1
-      className={cn(
-        'mb-6 font-pixel text-2xl text-[var(--accent-primary)]',
-        className
-      )}
+      className={cn('mb-6 font-pixel text-2xl text-brand-primary', className)}
     >
       {title}
     </h1>

--- a/components/layout/Skeleton.tsx
+++ b/components/layout/Skeleton.tsx
@@ -6,8 +6,6 @@ interface ISkeletonProps {
 
 export default function Skeleton({ className }: ISkeletonProps) {
   return (
-    <div
-      className={cn('animate-pulse bg-[var(--border-secondary)]', className)}
-    />
+    <div className={cn('animate-pulse bg-outline-secondary', className)} />
   );
 }

--- a/components/navigation/tabbar/TabBar.tsx
+++ b/components/navigation/tabbar/TabBar.tsx
@@ -14,7 +14,7 @@ export default function TabBar({ username }: { username?: string }) {
   };
 
   return (
-    <div className="fixed bottom-0 left-0 right-0 mx-auto border-t-2 border-[var(--border-primary)] bg-[var(--bg-secondary)]">
+    <div className="fixed bottom-0 left-0 right-0 mx-auto border-t-2 border-outline-primary bg-surface-secondary">
       <nav className="mx-auto grid max-w-screen-md grid-cols-4">
         <TabItem
           href="/"

--- a/components/navigation/tabbar/TabItem.tsx
+++ b/components/navigation/tabbar/TabItem.tsx
@@ -19,16 +19,14 @@ export default function TabItem({
       href={href}
       className={cn(
         'flex flex-col items-center px-1 py-3',
-        'transition-colors hover:bg-[var(--hover-light)] dark:hover:bg-[var(--hover-bg)]',
-        isActive && 'bg-[var(--hover-light)] dark:bg-[var(--hover-bg)]'
+        'transition-colors hover:bg-interaction-primary',
+        isActive && 'bg-interaction-primary'
       )}
     >
       <div
         className={cn(
           'mb-1',
-          isActive
-            ? 'text-[var(--accent-primary)]'
-            : 'text-[var(--text-secondary)]'
+          isActive ? 'text-brand-primary' : 'text-content-secondary'
         )}
       >
         {icon}
@@ -36,9 +34,7 @@ export default function TabItem({
       <span
         className={cn(
           'font-pixel text-xs',
-          isActive
-            ? 'text-[var(--accent-primary)]'
-            : 'text-[var(--text-secondary)]'
+          isActive ? 'text-brand-primary' : 'text-content-secondary'
         )}
       >
         {label}

--- a/components/profile/PasswordChangeForm.tsx
+++ b/components/profile/PasswordChangeForm.tsx
@@ -70,7 +70,7 @@ export default function PasswordChangeForm() {
             text="비밀번호 변경"
             loadingText="변경 중..."
             type="submit"
-            className="w-auto border-[var(--accent-primary)] bg-[var(--accent-primary)] px-4 py-2 hover:border-[var(--accent-secondary)] hover:bg-[var(--accent-secondary)]"
+            className="w-auto border-brand-primary bg-brand-primary px-4 py-2 hover:border-brand-secondary hover:bg-brand-secondary"
           />
         </div>
       </form>

--- a/components/profile/ProfileEditError.tsx
+++ b/components/profile/ProfileEditError.tsx
@@ -9,14 +9,14 @@ export default function ProfileEditError({ username }: IProfileEditErrorProps) {
   return (
     <main className="mx-auto max-w-lg px-4 pb-20 pt-5">
       <div className="retro-container p-6 text-center">
-        <p className={cn('text-[var(--error)]')}>
+        <p className={cn('text-status-error')}>
           프로필 정보를 불러오는데 실패했습니다.
         </p>
         <Link
           href={`/users/${username}`}
           className={cn(
             'mt-4 inline-block',
-            'text-[var(--accent-primary)] hover:text-[var(--accent-secondary)]',
+            'text-brand-primary hover:text-brand-secondary',
             'hover:underline'
           )}
         >

--- a/components/profile/ProfileInfoForm.tsx
+++ b/components/profile/ProfileInfoForm.tsx
@@ -110,7 +110,7 @@ export default function ProfileInfoForm({
             id="bio"
             name="bio"
             rows={4}
-            className="retro-input w-full p-3 focus:border-[var(--accent-primary)]"
+            className="retro-input w-full p-3 focus:border-brand-primary"
             placeholder="자기소개를 입력해주세요."
             defaultValue={profile.bio || ''}
           />
@@ -120,7 +120,7 @@ export default function ProfileInfoForm({
             text="정보 변경"
             loadingText="변경 중..."
             type="submit"
-            className="w-auto border-[var(--accent-primary)] bg-[var(--accent-primary)] px-4 py-2 hover:border-[var(--accent-secondary)] hover:bg-[var(--accent-secondary)]"
+            className="w-auto border-brand-primary bg-brand-primary px-4 py-2 hover:border-brand-secondary hover:bg-brand-secondary"
           />
         </div>
       </form>

--- a/components/profile/UserWithdrawalButton.tsx
+++ b/components/profile/UserWithdrawalButton.tsx
@@ -22,7 +22,7 @@ export default function UserWithdrawalButton() {
         onClick={handleOpenModal}
         className={cn(
           'flex w-full items-center justify-between p-4 text-left transition',
-          'text-[var(--error)] hover:bg-[var(--error-light)]'
+          'text-status-error hover:bg-status-error-light'
         )}
       >
         <span className="text-base">회원 탈퇴</span>

--- a/components/profile/WithdrawalConfirmModal.tsx
+++ b/components/profile/WithdrawalConfirmModal.tsx
@@ -43,20 +43,16 @@ export default function WithdrawalConfirmModal({
 
   return (
     <ModalWrapper isOpen={isOpen} onCloseAction={onCloseAction}>
-      <h2 className="mb-4 text-lg font-medium text-[var(--error)]">
-        회원 탈퇴
-      </h2>
+      <h2 className="mb-4 text-lg font-medium text-status-error">회원 탈퇴</h2>
       <div className="mb-6">
-        <p className="mb-2 text-[var(--text-primary)]">
-          정말로 탈퇴하시겠습니까?
-        </p>
-        <p className="text-sm text-[var(--text-secondary)]">
+        <p className="mb-2 text-content-primary">정말로 탈퇴하시겠습니까?</p>
+        <p className="text-sm text-content-secondary">
           • 모든 트윗, 좋아요, 댓글이 삭제됩니다.
         </p>
-        <p className="text-sm text-[var(--text-secondary)]">
+        <p className="text-sm text-content-secondary">
           • 삭제된 데이터는 복구할 수 없습니다.
         </p>
-        <p className="text-sm text-[var(--text-secondary)]">
+        <p className="text-sm text-content-secondary">
           • 동일한 이메일로 재가입이 가능합니다.
         </p>
       </div>
@@ -74,7 +70,7 @@ export default function WithdrawalConfirmModal({
           <button
             type="button"
             onClick={onCloseAction}
-            className="retro-button border-[var(--border-primary)] bg-[var(--bg-secondary)] px-4 py-2 hover:bg-[var(--hover-light)]"
+            className="retro-button border-outline-primary bg-surface-secondary px-4 py-2 hover:bg-interaction-secondary"
           >
             취소
           </button>
@@ -82,7 +78,7 @@ export default function WithdrawalConfirmModal({
             text="탈퇴하기"
             loadingText="처리 중..."
             type="submit"
-            className="w-auto border-[var(--error)] bg-[var(--error)] px-4 py-2 hover:border-[var(--error)] hover:bg-[var(--error)] hover:opacity-90"
+            className="w-auto border-status-error bg-status-error px-4 py-2 hover:border-status-error hover:bg-status-error hover:opacity-90"
           />
         </div>
       </form>

--- a/components/response/ResponseContainer.tsx
+++ b/components/response/ResponseContainer.tsx
@@ -103,12 +103,7 @@ export default function ResponseContainer({
 
   return (
     <div className="mt-6">
-      <h3
-        className={cn(
-          'mb-4 text-base font-medium',
-          'text-[var(--text-primary)] dark:text-[var(--accent-primary)]'
-        )}
-      >
+      <h3 className={cn('mb-4 text-base font-medium text-brand-primary')}>
         댓글 {optimisticResponses.length}개
       </h3>
 

--- a/components/response/ResponseEditMode.tsx
+++ b/components/response/ResponseEditMode.tsx
@@ -62,13 +62,11 @@ export default function ResponseEditMode({
   return (
     <div className="p-4">
       <div className="mb-2 flex justify-between">
-        <span className="font-medium text-[var(--text-primary)]">
-          댓글 수정
-        </span>
+        <span className="font-medium text-content-primary">댓글 수정</span>
         <div
           className={cn(
             'text-sm',
-            isOverLimit ? 'text-[var(--error)]' : 'text-[var(--text-secondary)]'
+            isOverLimit ? 'text-status-error' : 'text-content-secondary'
           )}
         >
           {`${charCount}/${TWEET_VALIDATION.MAX_LENGTH}`}
@@ -79,7 +77,7 @@ export default function ResponseEditMode({
         <textarea
           value={content}
           onChange={(e) => setContent(e.target.value)}
-          className="retro-input min-h-20 w-full p-3 text-base placeholder:text-[var(--text-secondary)] focus:border-[var(--accent-primary)]"
+          className="retro-input min-h-20 w-full p-3 text-base placeholder:text-content-secondary focus:border-brand-primary"
           rows={3}
           maxLength={TWEET_VALIDATION.MAX_LENGTH}
           disabled={isPending}
@@ -93,8 +91,8 @@ export default function ResponseEditMode({
             onClick={onCancelAction}
             className={cn(
               'retro-button px-3 py-1 text-sm',
-              'border-[var(--border-primary)] bg-[var(--bg-tertiary)]',
-              'hover:bg-[var(--hover-light)]'
+              'border-outline-primary bg-surface-tertiary',
+              'hover:bg-interaction-secondary'
             )}
             disabled={isPending}
           >
@@ -105,8 +103,8 @@ export default function ResponseEditMode({
             loadingText="저장 중..."
             className={cn(
               'w-auto px-3 py-1 text-sm',
-              'border-[var(--accent-primary)] bg-[var(--accent-primary)]',
-              'text-black hover:border-[var(--accent-secondary)] hover:bg-[var(--accent-secondary)]'
+              'border-brand-primary bg-brand-primary',
+              'text-special-button-on-accent hover:border-brand-primary hover:bg-brand-secondary'
             )}
             disabled={isInvalid}
           />

--- a/components/response/ResponseForm.tsx
+++ b/components/response/ResponseForm.tsx
@@ -69,7 +69,7 @@ export default function ResponseForm({
             name="content"
             value={responseText}
             onChange={(e) => setResponseText(e.target.value)}
-            className="retro-input min-h-20 w-full p-3 text-base placeholder:text-[var(--text-secondary)] focus:border-[var(--accent-primary)]"
+            className="retro-input min-h-20 w-full p-3 text-base placeholder:text-content-secondary focus:border-brand-primary"
             rows={3}
             placeholder="댓글을 작성해주세요."
             maxLength={TWEET_VALIDATION.MAX_LENGTH}

--- a/components/response/ResponseList.tsx
+++ b/components/response/ResponseList.tsx
@@ -25,8 +25,8 @@ export default function ResponseList({
         <div
           key={response.id}
           className={cn(
-            'border-b-2 border-[var(--border-primary)] last:border-b-0',
-            response.id < 0 && 'bg-[var(--accent-light)]'
+            'border-b-2 border-brand-primary last:border-b-0',
+            response.id < 0 && 'bg-brand-light'
           )}
         >
           <ResponseItem

--- a/components/response/ResponseViewMode.tsx
+++ b/components/response/ResponseViewMode.tsx
@@ -70,9 +70,7 @@ export default function ResponseViewMode({
             {username}
           </Link>
           {isPending && (
-            <span className="text-xs text-[var(--accent-primary)]">
-              (게시 중...)
-            </span>
+            <span className="text-xs text-brand-primary">(게시 중...)</span>
           )}
         </div>
 
@@ -82,7 +80,7 @@ export default function ResponseViewMode({
               onClick={onEditClickAction}
               className={cn(
                 'text-sm transition-colors',
-                'text-[var(--accent-primary)] hover:text-[var(--accent-secondary)]'
+                'text-brand-primary hover:text-brand-secondary'
               )}
             >
               수정
@@ -92,7 +90,7 @@ export default function ResponseViewMode({
               disabled={isDeleting}
               className={cn(
                 'text-sm transition-colors',
-                'text-[var(--error)] hover:text-[var(--error)]',
+                'text-status-error hover:text-status-error',
                 'disabled:cursor-not-allowed disabled:opacity-50'
               )}
             >

--- a/components/search/SearchForm.tsx
+++ b/components/search/SearchForm.tsx
@@ -30,15 +30,15 @@ export default function SearchForm({ initialQuery = '' }: ISearchFormProps) {
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           placeholder="검색어를 입력하세요."
-          className="retro-input w-full py-3 pl-3 pr-12 focus:border-[var(--accent-primary)]"
+          className="retro-input w-full py-3 pl-3 pr-12 focus:border-brand-primary"
         />
         <button
           type="submit"
           className={cn(
             'absolute right-0 top-0 h-full px-4 transition-colors',
             disabled
-              ? 'cursor-not-allowed text-[var(--text-tertiary)]'
-              : 'cursor-pointer text-[var(--accent-primary)]'
+              ? 'cursor-not-allowed text-content-tertiary'
+              : 'cursor-pointer text-brand-primary'
           )}
           disabled={disabled}
         >

--- a/components/search/SearchLoadingSkeleton.tsx
+++ b/components/search/SearchLoadingSkeleton.tsx
@@ -1,8 +1,8 @@
 export default function SearchLoadingSkeleton() {
   return (
     <div className="mt-8 flex flex-col items-center justify-center">
-      <div className="h-10 w-10 animate-spin rounded-full border-4 border-[var(--text-primary)] border-t-transparent dark:border-[var(--accent-primary)] dark:border-t-transparent" />
-      <p className="mt-2 text-[var(--text-secondary)]">검색 중...</p>
+      <div className="h-10 w-10 animate-spin rounded-full border-4 border-brand-primary border-t-transparent" />
+      <p className="mt-2 text-content-secondary">검색 중...</p>
     </div>
   );
 }

--- a/components/settings/DarkModeToggle.tsx
+++ b/components/settings/DarkModeToggle.tsx
@@ -29,12 +29,12 @@ export default function DarkModeToggle({ initialTheme }: IDarkModeToggleProps) {
       disabled={isPending}
       className={cn(
         'flex w-full items-center justify-between p-4 transition',
-        'hover:bg-[var(--hover-light)] dark:hover:bg-[var(--hover-bg)]'
+        'hover:bg-interaction-primary'
       )}
     >
       <span className="flex items-center gap-3">
         {currentTheme === 'dark' ? (
-          <Moon className="size-5 text-[var(--accent-primary)]" />
+          <Moon className="size-5 text-brand-primary" />
         ) : (
           <Monitor className="size-5" />
         )}
@@ -44,7 +44,7 @@ export default function DarkModeToggle({ initialTheme }: IDarkModeToggleProps) {
         <div className="retro-container h-6 w-12 p-0">
           <div
             className={cn(
-              'absolute top-1 size-4 bg-[var(--accent-primary)] transition-transform',
+              'absolute top-1 size-4 bg-brand-primary transition-transform',
               currentTheme === 'dark' ? 'translate-x-6' : 'translate-x-1'
             )}
           />

--- a/components/settings/DarkModeToggle.tsx
+++ b/components/settings/DarkModeToggle.tsx
@@ -17,7 +17,6 @@ export default function DarkModeToggle({ initialTheme }: IDarkModeToggleProps) {
     const newTheme = currentTheme === 'light' ? 'dark' : 'light';
 
     setCurrentTheme(newTheme);
-    document.documentElement.className = newTheme;
 
     startTransition(async () => {
       await setTheme(newTheme);

--- a/components/settings/LogoutButton.tsx
+++ b/components/settings/LogoutButton.tsx
@@ -16,7 +16,7 @@ export default function LogoutButton() {
       onClick={handleLogout}
       className={cn(
         'flex w-full items-center justify-between p-4 text-left transition',
-        'text-[var(--error)] hover:bg-[var(--hover-light)]'
+        'text-status-error hover:bg-interaction-secondary'
       )}
     >
       <span className="text-base">로그아웃</span>

--- a/components/tweet/AddTweet.tsx
+++ b/components/tweet/AddTweet.tsx
@@ -41,22 +41,20 @@ export default function AddTweet() {
           name="tweet"
           value={tweetText}
           onChange={handleTextChange}
-          className="retro-input min-h-20 w-full p-3 text-base placeholder:text-[var(--text-secondary)] focus:border-[var(--accent-primary)]"
+          className="retro-input min-h-20 w-full p-3 text-base placeholder:text-content-secondary focus:border-brand-primary"
           placeholder="무슨 일이 일어나고 있나요?"
           rows={3}
           maxLength={TWEET_VALIDATION.MAX_LENGTH}
           minLength={TWEET_VALIDATION.MIN_LENGTH}
         />
         <div className="mt-2 flex items-center justify-between">
-          <small className="text-sm text-[var(--error)]">
+          <small className="text-sm text-status-error">
             {state.fieldErrors?.tweet}
           </small>
           <div
             className={cn(
               'text-sm',
-              isOverLimit
-                ? 'text-[var(--error)]'
-                : 'text-[var(--text-secondary)]'
+              isOverLimit ? 'text-status-error' : 'text-content-secondary'
             )}
           >
             {`${charCount}/${TWEET_VALIDATION.MAX_LENGTH}`}

--- a/components/tweet/DeleteTweetButton.tsx
+++ b/components/tweet/DeleteTweetButton.tsx
@@ -45,7 +45,7 @@ export default function DeleteTweetButton({
     <button
       onClick={handleDelete}
       disabled={isDeleting}
-      className="retro-button border-[var(--error)] bg-[var(--error)] px-4 py-2 text-sm font-medium text-white hover:bg-[var(--error)] disabled:cursor-not-allowed disabled:opacity-50"
+      className="retro-button border-status-error bg-status-error px-4 py-2 text-sm font-medium text-white hover:bg-status-error disabled:cursor-not-allowed disabled:opacity-50"
     >
       {isDeleting ? '삭제 중...' : '삭제'}
     </button>

--- a/components/tweet/EditTweetForm.tsx
+++ b/components/tweet/EditTweetForm.tsx
@@ -72,7 +72,7 @@ export default function EditTweetForm({ tweet }: IEditTweetFormProps) {
           name="tweet"
           value={tweetText}
           onChange={handleTextChange}
-          className="retro-input min-h-20 w-full p-3 text-base placeholder:text-[var(--text-secondary)] focus:border-[var(--accent-primary)]"
+          className="retro-input min-h-20 w-full p-3 text-base placeholder:text-content-secondary focus:border-brand-primary"
           rows={5}
           maxLength={TWEET_VALIDATION.MAX_LENGTH}
           minLength={TWEET_VALIDATION.MIN_LENGTH}
@@ -82,9 +82,7 @@ export default function EditTweetForm({ tweet }: IEditTweetFormProps) {
           <div
             className={cn(
               'text-sm',
-              isOverLimit
-                ? 'text-[var(--error)]'
-                : 'text-[var(--text-secondary)]'
+              isOverLimit ? 'text-status-error' : 'text-content-secondary'
             )}
           >
             {`${charCount}/${TWEET_VALIDATION.MAX_LENGTH}`}
@@ -96,7 +94,7 @@ export default function EditTweetForm({ tweet }: IEditTweetFormProps) {
             loadingText="수정 중..."
             type="submit"
             disabled={isInvalid}
-            className="w-auto border-[var(--accent-primary)] bg-[var(--accent-primary)] px-4 py-2 text-[var(--button-text-on-accent)] hover:border-[var(--accent-secondary)] hover:bg-[var(--accent-secondary)] disabled:border-[var(--border-secondary)] disabled:bg-[var(--border-secondary)]"
+            className="w-auto border-brand-primary bg-brand-primary px-4 py-2 text-special-button-on-accent hover:border-brand-secondary hover:bg-brand-secondary disabled:border-outline-secondary disabled:bg-outline-secondary"
           />
         </div>
       </form>

--- a/components/tweet/TweetList.tsx
+++ b/components/tweet/TweetList.tsx
@@ -28,14 +28,14 @@ const TweetList = ({
             href={`/tweets/${tweet.id}`}
             className={cn(
               '-m-4 block p-4 transition',
-              'hover:bg-[var(--hover-light)] dark:hover:bg-[var(--hover-bg)]'
+              'hover:bg-interaction-primary'
             )}
           >
-            <div className="font-medium text-[var(--accent-primary)]">
+            <div className="text-brand-primary font-medium">
               {tweet.user.username}
             </div>
             <p className="mt-1 whitespace-pre-wrap">{tweet.tweet}</p>
-            <div className="mt-2 flex items-center justify-between text-xs text-[var(--text-secondary)]">
+            <div className="text-content-secondary mt-2 flex items-center justify-between text-xs">
               <span>{formatToKorDate(tweet.created_at)}</span>
               <div className="flex items-center space-x-4">
                 <span className="flex items-center">

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,11 +5,52 @@ module.exports = {
     './components/**/*.{js,ts,jsx,tsx,mdx}',
     './app/**/*.{js,ts,jsx,tsx,mdx}',
   ],
+  darkMode: 'class',
   theme: {
     extend: {
       fontFamily: {
         pixel: ['Press Start 2P', 'monospace'],
         mono: ['Space Mono', 'monospace'],
+      },
+      colors: {
+        // 배경 색상
+        surface: {
+          primary: 'var(--bg-primary)',
+          secondary: 'var(--bg-secondary)',
+          tertiary: 'var(--bg-tertiary)',
+        },
+        // 텍스트 및 콘텐츠 색상
+        content: {
+          primary: 'var(--text-primary)',
+          secondary: 'var(--text-secondary)',
+          tertiary: 'var(--text-tertiary)',
+        },
+        // 테두리 색상
+        outline: {
+          primary: 'var(--border-primary)',
+          secondary: 'var(--border-secondary)',
+        },
+        // 브랜드/강조 색상
+        brand: {
+          primary: 'var(--accent-primary)',
+          secondary: 'var(--accent-secondary)',
+          light: 'var(--accent-light)',
+        },
+        // 상태 색상
+        status: {
+          error: 'var(--error)',
+          'error-light': 'var(--error-light)',
+          success: 'var(--success)',
+        },
+        // 인터랙션 색상
+        interaction: {
+          primary: 'var(--hover-primary)',
+          secondary: 'var(--hover-secondary)',
+        },
+        // 특수 용도
+        special: {
+          'button-on-accent': 'var(--button-text-on-accent)',
+        },
       },
     },
   },


### PR DESCRIPTION
## 개요
CSS 변수 직접 사용을 Tailwind 커스텀 색상 시스템으로 전환하여 코드 일관성과 개발 경험을 개선

## 주요 변경사항
- `tailwind.config.js`에 surface/content/brand/status 기반 색상 매핑 추가
- 모든 컴포넌트에서 `bg-[var(--*)]` → `bg-surface-*` 형태로 전환
- CSS 변수 네이밍 통일 (`hover-light/hover-bg` → `hover-primary/secondary`)
- `dark:` prefix 제거로 코드 간소화

Closes #53